### PR TITLE
Fix ValueError with default discogs_sold_folder_id

### DIFF
--- a/discodos/ctrl/collection.py
+++ b/discodos/ctrl/collection.py
@@ -431,6 +431,10 @@ class CollectionControlCommandline (ControlCommon, CollectionControlCommon):
     def create_collection_item(self, instance, sold_folder_id=None):
         """Creates a collection item by passing a dictionary to the DiscoBASE method."""
         value_f3 = self.cli.extract_collection_item_notes(instance)
+        # Handle discogs_sold_folder_id config setting
+        coll_sold = 0
+        if sold_folder_id != 0 and is_number(sold_folder_id):
+            coll_sold = instance["folder_id"] == int(sold_folder_id)
 
         self.collection.create_collection_item(
             {
@@ -440,7 +444,7 @@ class CollectionControlCommandline (ControlCommon, CollectionControlCommon):
                 "d_coll_added": instance["date_added"],
                 "d_coll_rating": instance["rating"],
                 "d_coll_notes": value_f3,
-                "coll_sold": instance["folder_id"] == int(sold_folder_id),
+                "coll_sold": coll_sold,
                 "coll_orphaned": 0,  # Temporary reset fix. FIXME
                 "coll_mtime": timestamp_now(),
             }


### PR DESCRIPTION
as reported in issue #40.

The `config.yaml` setting `discogs_sold_folder_id` defaults to '' (empty string), the comparision in `create_collection_folder()` tries to cast an int from it which can only fail with a ValueError.

Now it's sanity-checked if we have a number we can compare with or fall back to simply designate the sold state as 0 (not sold). Numbers as strings in `config.yaml` will also work (typically users will put their id between the empty string quotes instead of replacing the whole yaml value with a real number).